### PR TITLE
Fix world unload event listener

### DIFF
--- a/eco-core/core-plugin/src/main/java/net/refractored/bloodmoonreloaded/listeners/OnWorldUnload.kt
+++ b/eco-core/core-plugin/src/main/java/net/refractored/bloodmoonreloaded/listeners/OnWorldUnload.kt
@@ -3,11 +3,11 @@ package net.refractored.bloodmoonreloaded.listeners
 import net.refractored.bloodmoonreloaded.registry.BloodmoonRegistry
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.bukkit.event.world.WorldLoadEvent
+import org.bukkit.event.world.WorldUnloadEvent
 
 class OnWorldUnload : Listener {
     @EventHandler
-    fun execute(event: WorldLoadEvent) {
+    fun execute(event: WorldUnloadEvent) {
         BloodmoonRegistry.getWorld(event.world.name) ?: return
         BloodmoonRegistry.unregisterWorld(event.world.name)
     }


### PR DESCRIPTION
## Summary
- fix world unload listener to use `WorldUnloadEvent`

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a60c61d3883209d92c0a9c1400ccd